### PR TITLE
Fix in JsonDecoder class - replaced create_function with an anonymous

### DIFF
--- a/src/JsonDecoder.php
+++ b/src/JsonDecoder.php
@@ -5,13 +5,12 @@ namespace Dto;
 // TODO: throw our own Exceptions to really keep the JsonDecoder separate
 use Dto\Exceptions\JsonDecodingException;
 
-class JsonDecoder implements JsonDecoderInterface
-{
+class JsonDecoder implements JsonDecoderInterface {
+
     /**
      * @inheritdoc
      */
-    public function decodeString($string)
-    {
+    public function decodeString($string) {
 
         $result = json_decode($string, true);
 
@@ -31,10 +30,9 @@ class JsonDecoder implements JsonDecoderInterface
     {
         // https://stackoverflow.com/questions/272361/how-can-i-handle-the-warning-of-file-get-contents-function-in-php
         set_error_handler(
-            create_function(
-                '$severity, $message, $file, $line',
-                'throw new \Dto\Exceptions\JsonDecodingException($message, $severity);'
-            )
+            function ($severity, $message, $file, $line) {
+                throw new \Dto\Exceptions\JsonDecodingException($message, $severity);
+            }
         );
 
         $content = file_get_contents($filepath);


### PR DESCRIPTION
Created an issue for this fix, this fixes the `JsonDecoder` class for PHP 7.2 since `create_function` was deprecated.